### PR TITLE
Update Dockerfile to incporporate recent version of docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM docker:17.03.0
 
-ARG compose_version=1.11.2
+ARG compose_version=1.18.0
 
 # Install docker-compose (extra complicated since the base image uses alpine as base)
 RUN apk update && apk add --no-cache \


### PR DESCRIPTION
As mentioned [here](https://github.com/jonaskello/docker-and-compose/issues/2) this PR is introducing a recent version (as of 01-2018) of `docker-compose` to enable the usage certain new features of `docker-compose` like `--exit-code-from some-service` . 